### PR TITLE
Inter contract communication POC

### DIFF
--- a/contracts/TestTwoSum.scilla
+++ b/contracts/TestTwoSum.scilla
@@ -1,0 +1,30 @@
+scilla_version 0
+
+library TestTwoSum
+
+let one_msg = 
+  fun (msg : Message) => 
+  let nil_msg = Nil {Message} in
+  Cons {Message} msg nil_msg
+
+contract TestTwoSum
+()
+
+transition Test (contractAddress : ByStr20)
+  msg = {_tag : "TwoSum"; _recipient : contractAddress; _amount : Uint128 0; a : Uint32 1; b : Uint32 1};
+  msgs = one_msg msg;
+  send msgs
+end
+
+transition ListenResult (ans : Uint32)
+  two = Uint32 2;
+  is_correct = builtin eq ans two;
+  match is_correct with
+  | True =>
+    e = {_eventname: "TestResult"; result : "Pass"};
+    event e
+  | False =>
+    e = {_eventname: "TestResult"; result : "Fail"};
+    event e
+  end
+end

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "run:isolated-server": "docker run --name zrc_local -d -p 5555:5555 --entrypoint isolatedServer zilliqa/zilliqa-isolated-server:a01fe00 -t 5000 -f boot.json -u 0",
     "rm:isolated-server": "docker stop zrc_local | xargs docker rm",
     "test": "cross-env PORT=5555 jest --verbose --runInBand",
+    "test:watch": "cross-env PORT=5555 jest --verbose --runInBand --watch",
     "test:ci": "npm run run:isolated-server; npm run test && npm run rm:isolated-server",
     "format": "npx prettier --write ."
   },

--- a/tests/TestTwoSum.test.ts
+++ b/tests/TestTwoSum.test.ts
@@ -1,0 +1,161 @@
+import { Zilliqa } from "@zilliqa-js/zilliqa";
+import { expect } from "@jest/globals";
+import { getAddressFromPrivateKey, schnorr } from "@zilliqa-js/crypto";
+import { scillaJSONParams } from "@zilliqa-js/scilla-json-utils";
+
+import {
+  expectEvents,
+  expectTransitions,
+} from "./testutils";
+
+import {
+  API,
+  TX_PARAMS,
+  getContractCode,
+  FAUCET_PARAMS,
+} from "./config";
+
+const JEST_WORKER_ID = Number(process.env["JEST_WORKER_ID"]);
+const GENESIS_PRIVATE_KEY = global.GENESIS_PRIVATE_KEYS[JEST_WORKER_ID - 1];
+
+const zilliqa = new Zilliqa(API);
+zilliqa.wallet.addByPrivateKey(GENESIS_PRIVATE_KEY);
+
+let testerContractAddress;
+let testeeContractAddress;
+
+let globalTestAccounts: Array<{
+  privateKey: string;
+  address: string;
+}> = [];
+const CONTRACT_OWNER = 0;
+const TOKEN_OWNER = 0;
+const MINTER = 1;
+const STRANGER = 2;
+const getTestAddr = (index) => globalTestAccounts[index]?.address as string;
+
+beforeAll(async () => {
+  const accounts = Array.from({ length: 3 }, schnorr.generatePrivateKey).map(
+    (privateKey) => ({
+      privateKey,
+      address: getAddressFromPrivateKey(privateKey),
+    })
+  );
+
+  for (const { privateKey, address } of accounts) {
+    zilliqa.wallet.addByPrivateKey(privateKey);
+    const tx = await zilliqa.blockchain.createTransaction(
+      zilliqa.transactions.new(
+        {
+          ...FAUCET_PARAMS,
+          toAddr: address,
+        },
+        false
+      )
+    );
+    if (!tx.getReceipt()?.success) {
+      throw new Error();
+    }
+  }
+  globalTestAccounts = accounts;
+
+  console.table({
+    JEST_WORKER_ID,
+    GENESIS_PRIVATE_KEY,
+    CONTRACT_OWNER: getTestAddr(CONTRACT_OWNER),
+    TOKEN_OWNER: getTestAddr(TOKEN_OWNER),
+    MINTER: getTestAddr(MINTER),
+    STRANGER: getTestAddr(STRANGER),
+  });
+});
+
+async function deployContract(contractCode: string) {
+  const init = scillaJSONParams({
+    _scilla_version: ["Uint32", 0],
+  });
+  const [, contract] = await zilliqa.contracts
+    .new(contractCode, init)
+    .deploy(TX_PARAMS, 33, 1000, true);
+  if (contract.address === undefined) {
+    throw new Error();
+  }
+  return contract.address
+}
+
+beforeEach(async () => {
+  zilliqa.wallet.setDefault(getTestAddr(CONTRACT_OWNER));
+  testerContractAddress = await deployContract(getContractCode("contracts/TestTwoSum.scilla"));
+  testeeContractAddress = await deployContract(getContractCode("tests/contracts/TwoSum.scilla"));
+});
+
+describe("TwoSum", () => {
+  it("should be able to add two numbers", async () => {
+    zilliqa.wallet.setDefault(getTestAddr(CONTRACT_OWNER));
+    const tx: any = await zilliqa.contracts
+      .at(testeeContractAddress)
+      .call(
+        "TwoSum",
+        scillaJSONParams({
+          a: ["Uint32", 1],
+          b: ["Uint32", 1]
+        }),
+        TX_PARAMS
+      );
+
+    expect(tx.receipt.success).toBe(true);
+
+    expectTransitions(tx.receipt.transitions, [
+      {
+        tag: "ListenResult",
+        getParams: () => ({
+          res: ["Uint32", 2],
+        }),
+      },
+    ]);
+  })
+})
+
+describe("TestTwoSum", () => {
+  it("should be call TwoSum and emit pass event", async () => {
+    zilliqa.wallet.setDefault(getTestAddr(CONTRACT_OWNER));
+    const tx: any = await zilliqa.contracts
+      .at(testerContractAddress)
+      .call(
+        "Test",
+        scillaJSONParams({
+          contractAddress: ["ByStr20", testeeContractAddress]
+        }),
+        TX_PARAMS
+      );
+
+    expect(tx.receipt.success).toBe(true);
+    
+    expectTransitions(tx.receipt.transitions, [
+      {
+        tag: "TwoSum",
+        getParams: () => ({
+          a: ["Uint32", 1],
+          b: ["Uint32", 1],
+        }),
+        addr: testeeContractAddress,
+      },
+      {
+        tag: "ListenResult",
+        getParams: () => ({
+          ans: ["Uint32", 2],
+        }),
+        addr: testerContractAddress,
+      },
+    ]);
+
+    expectEvents(tx.receipt.event_logs, [
+      {
+        name: "TestResult",
+        params: {
+          result: ["String", "Pass"],
+        },
+      }
+    ])
+    
+  });
+})

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -7,9 +7,12 @@ export const CHAIN_ID = 222;
 export const MSG_VERSION = 1;
 export const VERSION = bytes.pack(CHAIN_ID, MSG_VERSION);
 
-const CODE_PATH = "contract/HelloWorld.scilla";
+const CODE_PATH = "contracts/HelloWorld.scilla";
 export const CODE = fs.readFileSync(CODE_PATH).toString();
 
+export function getContractCode(path: string) {
+  return fs.readFileSync(path).toString();
+}
 export const TOKEN_NAME = "TEST";
 export const TOKEN_SYMBOL = "T";
 

--- a/tests/contracts/TwoSum.scilla
+++ b/tests/contracts/TwoSum.scilla
@@ -1,0 +1,25 @@
+scilla_version 0
+
+library TwoSum
+
+let one_msg = 
+  fun (msg : Message) => 
+    let nil_msg = Nil {Message} in
+    Cons {Message} msg nil_msg
+
+contract TwoSum
+()
+
+transition TwoSum (a : Uint32, b : Uint32)
+
+  (* User implementation start *)
+
+  res = builtin add a b;
+
+  (* User implementation end *)
+
+  m = {_tag : "ListenResult"; _recipient : _sender; _amount : Uint128 0; ans : res};
+  mone = one_msg m;
+  send mone
+  
+end

--- a/tests/testutils.ts
+++ b/tests/testutils.ts
@@ -11,3 +11,18 @@ export const expectEvents = (events, want) => {
     expect(JSON.stringify(event.params)).toBe(JSON.stringify(wantParams));
   }
 };
+
+export const expectTransitions = (transitions, want) => {
+  if (transitions === undefined) {
+    expect(undefined).toBe(want);
+  }
+  for (const [index, transition] of transitions.entries()) {
+    const { msg } = transition;
+    expect(want[index].tag).toBe(want[index].tag);
+    const wantParams = scillaJSONParams(want[index].getParams());
+    expect(JSON.stringify(msg.params)).toBe(JSON.stringify(wantParams));
+    if (want.addr) {
+      expect(transition.addr).toBe(want.addr);
+    }
+  }
+};


### PR DESCRIPTION
Implemented TestTwoSum and TwoSum contracts

- `TwoSum.scilla` will be written by user and deployed to the chain
- User using our react frontend will call `TestTwoSum.scilla`'s `Test` transition
- If `TwoSum.scilla` fulfil all requirements (sum inputs a and b in this case), a `TestResult` event with `result` value as "Passed" will be emitted

See test cases `TestTwoSum: should be call TwoSum and emit pass event` illustrating this flow.

When the Profile contract is implemented, an additional message will be sent to the Profile contract right after the `TestResult` is emitted (if `event.result == passed`), setting the achievement to `true` in user's profile.